### PR TITLE
Updated to use ComputerCraft colours

### DIFF
--- a/apps/code/blocks-colour.js
+++ b/apps/code/blocks-colour.js
@@ -29,37 +29,37 @@
  */
 var COLOURS_ = [
   // WHITE
-  { rgb: '#ffffff', value: 1 << 0 },
+  { rgb: '#f0f0f0', value: 1 << 0 },
   // ORANGE
-  { rgb: '#ffa000', value: 1 << 1 },
+  { rgb: '#f2b233', value: 1 << 1 },
   // MAGENTA
-  { rgb: '#ff00ff', value: 1 << 2 },
+  { rgb: '#e57fd8', value: 1 << 2 },
   // LIGHT_BLUE
-  { rgb: '#87ceeb', value: 1 << 3 },
+  { rgb: '#99b2f2', value: 1 << 3 },
   // YELLOW
-  { rgb: '#ffff00', value: 1 << 4 },
+  { rgb: '#dede6c', value: 1 << 4 },
   // LIME
-  { rgb: '#32cd32', value: 1 << 5 },
+  { rgb: '#7fcc19', value: 1 << 5 },
   // PINK
-  { rgb: '#ff77ff', value: 1 << 6 },
+  { rgb: '#f2b2cc', value: 1 << 6 },
   // GREY
-  { rgb: '#808080', value: 1 << 7 },
+  { rgb: '#4c4c4c', value: 1 << 7 },
   // LIGHT_GREY
-  { rgb: '#d3d3d3', value: 1 << 8 },
+  { rgb: '#999999', value: 1 << 8 },
   // CYAN
-  { rgb: '#00ffff', value: 1 << 9 },
+  { rgb: '#4c99b2', value: 1 << 9 },
   // PURPLE
-  { rgb: '#a020f0', value: 1 << 10 },
+  { rgb: '#b266e5', value: 1 << 10 },
   // BLUE
-  { rgb: '#0000cd', value: 1 << 11 },
+  { rgb: '#253192', value: 1 << 11 },
   // BROWN
-  { rgb: '#8b4513', value: 1 << 12 },
+  { rgb: '#7f664c', value: 1 << 12 },
   // GREEN
-  { rgb: '#228b22', value: 1 << 13 },
+  { rgb: '#57a64e', value: 1 << 13 },
   // RED
-  { rgb: '#ff0000', value: 1 << 14 },
+  { rgb: '#cc4c4c', value: 1 << 14 },
   // BLACK
-  { rgb: '#000000', value: 1 << 15 }
+  { rgb: '#191919', value: 1 << 15 }
 ];
 
 /**


### PR DESCRIPTION
**Bugs found:**
- Colour palette block's default is not something picked from the palettes colour list, it is instead a static `#ff0000` this should be addressed
- Generating the Lua code places a hex string for example `"#ff0000"` instead of either `colours.red` or `16384`
- _[known]_ hovering over the colour the tooltip shows the rgb _[proposed fix]_ perhaps have another key in the array of colours that specifies tooltip?
